### PR TITLE
Get readthedocs Theme Locally

### DIFF
--- a/docs/About/Documentation.md
+++ b/docs/About/Documentation.md
@@ -29,8 +29,7 @@ to preview your changes
     * Run `mkdocs serve` in your command line. If there is an error
     building the docs locally, the error will be displayed within your 
     command line.
-    * Double check your changes at 127.0.0.1:8000 (theme served up by 
-    mkdocs locally is different than the theme that readthedocs provides).
+    * Double check your changes at 127.0.0.1:8000.
 5. Submit a pull request to master at 
 [TechEmpower/TFB-Documentation](https://github.com/TechEmpower/TFB-Documentation).
 6. Once your pull request is accepted, the site 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: /
 site_description: Documentation for TechEmpower Framework Benchmarks.
 site_favicon: img/favicon.png
 repo_url: https://github.com/TechEmpower/TFB-Documentation
+theme: readthedocs
 pages: 
 - ['index.md']
 


### PR DESCRIPTION
All we had to do is say what theme we're using in the mkdocs.yml and it is served up locally. 