### PR TITLE
Add missing information to documentation

### DIFF
--- a/docs/Codebase/Framework-Files.md
+++ b/docs/Codebase/Framework-Files.md
@@ -182,7 +182,9 @@ Here is an example `benchmark_config` from the `Compojure` framework. There are 
       }]
     }
 
-* `framework:` Specifies the framework name.
+* `framework:` Specifies the framework name, which is used when the tests are run and within TFB. 
+This allows you to call the default test with `toolset/run-tests.py --mode verify --test compojure`, 
+or call the other test with `toolset/run-tests.py --mode verify --test compojure-raw`.
 * `tests:` A list of tests that can be run for this framework. In many cases, this contains a single element for the "default" test, but additional tests can be specified.  Each test name must be unique when concatenated with the framework name. Each test will be run separately in our Rounds, so it is to your benefit to provide multiple variations in case one works better in some cases.
   * `setup_file:` The location of the [python setup file](#setup-file) that can start and stop the test, excluding the `.py` ending. If your different tests require different setup approachs, use another setup file. 
   * `json_url (optional):` The URI to the JSON test, typically `/json`
@@ -195,7 +197,7 @@ Here is an example `benchmark_config` from the `Compojure` framework. There are 
   * `approach (metadata):` `Realistic` or `Stripped` (see [here](http://www.techempower.com/benchmarks/#section=code&hw=peak&test=json) for a description of all metadata attributes)
   * `classification (metadata):` `Full`, `Micro`, or `Platform`
   * `database (metadata):` `MySQL`, `Postgres`, `MongoDB`, `SQLServer`, or `None`
-  * `framework (metadata):` name of the framework
+  * `framework (metadata):` name of the framework (only used to display information on the results site)
   * `language (metadata):` name of the language
   * `orm (metadata):` `Full`, `Micro`, or `Raw`
   * `platform (metadata):` name of the platform

--- a/docs/Codebase/index.md
+++ b/docs/Codebase/index.md
@@ -116,7 +116,7 @@ keys, as shown here:
 TFB does not use the numbers in any of the graphs but we include them for 
 other consumers of the data.
 
-_Note: The keys used are framework names (e.g. ringo) and not he framework 
+_Note: The keys used are framework names (e.g. ringo) and not the framework 
 test names (e.g. ringojs-raw)._
 
 ### toolset/

--- a/docs/Codebase/index.md
+++ b/docs/Codebase/index.md
@@ -16,6 +16,7 @@ Here are the relevant pieces of TFB's file structure:
             * [benchmark_config (Framework Specific File)](#framework-specific-files)
             * [install.sh (Framework Specific File)](#framework-specific-files)
             * [setup.sh (Framework Specific File)](#framework-specific-files)
+            * [source_code](#source-code-file)
             * et cetera...
         * gemini/
         * et cetera...
@@ -91,6 +92,32 @@ files that are required by the TFB suite. These are:
 
 See the section on [Framework Specific Files](Codebase/Framework-Files) 
 for more information.
+
+#### Source Code File
+
+The file named `source_code` within each framework is used to count the lines 
+of code in the project - each file listed in source_code has its lines counted 
+(we're using [CLOC](http://cloc.sourceforge.net/) to provide this functionality)
+and the result are include in `results.json` under the rawData > slocCounts 
+keys, as shown here:
+
+    "rawData": {
+      "slocCounts": {
+        "mojolicious": 72, 
+        "scruffy": 47, 
+        "nodejs": 217, 
+        "spring": 242, 
+        "cpoll-cppsp": 82, 
+        "slim": 1889, 
+        "dropwizard": 293, 
+        "revel": 258, 
+        "dancer": 32, 
+
+TFB does not use the numbers in any of the graphs but we include them for 
+other consumers of the data.
+
+_Note: The keys used are framework names (e.g. ringo) and not he framework 
+test names (e.g. ringojs-raw)._
 
 ### toolset/
 

--- a/docs/Development/Testing-and-Debugging.md
+++ b/docs/Development/Testing-and-Debugging.md
@@ -39,6 +39,8 @@ $ toolset/run-tests.py --test beego --max-concurrency 24 --max-threads 24 --dura
 # Run a tiny benchmark
 $ toolset/run-tests.py --test beego --max-threads 2 --max-concurrency 2 
 ```
+_Note: The `results` directory must be removed after each test has been run 
+in order to run the test again._
 
 # Testing on both Windows and Linux
 

--- a/docs/Project-Information/Environment.md
+++ b/docs/Project-Information/Environment.md
@@ -7,12 +7,10 @@ For language and framework specific details, view their README within their resp
 
 ##Hardware
 * [Peak](http://www.peakhosting.com/): Dell R720xd dual Xeon E5-2660 v2 servers with 32 GB memory; database servers equipped with SSDs in RAID; switched 10-gigabit Ethernet
-* i7: Sandy Bridge Core i7-2600K workstations with 8 GB memory (early 2011 vintage); database server equipped with Samsung 840 Pro SSD; switched gigabit Ethernet
-* EC2: Amazon EC2 m1.large instances; switched gigabit Ethernet
+* EC2: Amazon EC2 c3.large instances; switched gigabit Ethernet
 
 ##Operating Systems
 * [Ubuntu Linux](http://www.ubuntu.com/desktop) 12.04 64-bit
-* [Windows Server](http://www.microsoft.com/en-us/server-cloud/products/windows-server-2012-r2/default.aspx) 2012 64-bit
 
 ##Databases
 * [MySQL](http://dev.mysql.com/)

--- a/docs/Project-Information/Framework-Tests.md
+++ b/docs/Project-Information/Framework-Tests.md
@@ -121,7 +121,9 @@ The following requirements apply to all test types below.
     In addition to the requirements listed below, please note the [general requirements](#general-test-requirements) that apply to all implemented tests.
 
     1. For every request, an integer `query` string parameter named queries must be retrieved from the request. The parameter specifies the number of database queries to execute in preparing the HTTP response (see below).
-    2. The recommended URI is __/queries__.
+    2. The recommended URI is __/queries__. _Note: Whether there is an actual request 
+    parameter named `queries` is not important. The url should best reflect the 
+    practices of the particular framework. So, both "/queries?queries=" and "/queries/" are valid paths._
     3. The `queries` parameter must be bounded to between 1 and 500. If the parameter is missing, is not an integer, or is an integer less than 1, the value should be interpreted as 1; if greater than 500, the value should be interpreted as __500__.
     4. The request handler must retrieve a set of __World__ objects, equal in count to the `queries` parameter, from the __World__ database table.
     5. Each row must be selected randomly in the same fashion as the single database query test (Test #2 above).

--- a/docs/Project-Information/Results-Website.md
+++ b/docs/Project-Information/Results-Website.md
@@ -1,0 +1,23 @@
+# What is the Results Website?
+
+The results website is located at www.techempower.com/benchmarks. 
+The results are gathered in rounds and then displayed on the results 
+website for comparison. 
+
+# FAQ
+
+1. What is the purpose of the column named "Errors" on the results 
+website? (example is referencing round 8 results)
+
+> The very briefest answer is that the Errors column reports sum of the total number of 500-series responses and socket connection, read, or write errors reported by Wrk during the peak test.
+> 
+> 500-series responses are fairly straight-forward. For example, for wsgi-nginx-uwsgi, the peak plaintext performance was at 256 concurrency. Wrk reports that the server responded with non-200/300 responses (which we interpret as "500" responses) a total of 459,212 times. That is the number reported in the errors column for wsgi-nginx-uwsgi. This particular case had no socket connection, read, or write errors.
+> 
+> For Bottle, the peak performance was at 1,024 concurrency. We see Wrk reported 52 socket read errors and no other error types during that test.
+> 
+> Incidentally, in the results web site, the total requests completed is the requests count provided by Wrk less the errors. Looking at the wsgi-nginx-uwsgi results again, to determine RPS, we use code that works like this:
+
+        totalErrors = httpErrors + socketErrors;
+        rps = (totalRequestsReportedByWrk - totalErrors) / testDurationInSeconds;
+        Hence for uwsgi-nginx-uswgi it is:
+        (2117047 - 459212) / 15 = 110,522 successful RPS.  

--- a/docs/Support/FAQ.md
+++ b/docs/Support/FAQ.md
@@ -1,7 +1,7 @@
 1. There is synthetic routing implemented for the platforms that do not provide native routing. Should we force them to have similar routing logic to other platforms?
 
-> It's up to you, but adding trivial synthetic routing shouldn't affect the numbers to a measurable degree.
+    > It's up to you, but adding trivial synthetic routing shouldn't affect the numbers to a measurable degree.
 
 2. Is there any data visualization for the results if one would like to look at ones own results?
 
-> Yes, see [https://www.techempower.com/benchmarks/#section=test](https://www.techempower.com/benchmarks/#section=test).
+    > Yes, see [https://www.techempower.com/benchmarks/#section=test](https://www.techempower.com/benchmarks/#section=test).

--- a/docs/Support/FAQ.md
+++ b/docs/Support/FAQ.md
@@ -1,3 +1,7 @@
-1. Is there any data visualization for the results if one would like to look at ones own results?
+1. There is synthetic routing implemented for the platforms that do not provide native routing. Should we force them to have similar routing logic to other platforms?
 
-    Yes, see [https://www.techempower.com/benchmarks/#section=test](https://www.techempower.com/benchmarks/#section=test).
+> It's up to you, but adding trivial synthetic routing shouldn't affect the numbers to a measurable degree.
+
+2. Is there any data visualization for the results if one would like to look at ones own results?
+
+> Yes, see [https://www.techempower.com/benchmarks/#section=test](https://www.techempower.com/benchmarks/#section=test).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ pages:
 - ['Project-Information/Environment.md', 'Project Information', 'Environment']
 - ['Project-Information/Travis-CI.md', 'Project Information', 'Travis-CI']
 - ['Project-Information/Expected-Questions.md', 'Project Information', 'Expected Questions']
+- ['Project-Information/Results-Website.md', 'Project Information', 'Results Website']
 
 # Development:
 - ['Development/index.md', 'Development']


### PR DESCRIPTION
* Add a page for questions/explanations of the results website. 
* Explain what the errors column is on the results website (issue #9).
* Add an explanation of what source_code is on the code base outline (issue #1).
* Add note about /queries route format (issue #13).
* Add note regarding tests that provide synthetic routing because they don't have native routing (issue #12).
* Add note explaining that the results directory needs to be removed between testing each time a test is run (issue #11).
* Update the environment specifications to what they currently are (issue #10).
* Explain the difference more in depth between both "framework" keys within the benchmark_config (issue #8).