### PR TITLE
Updating docs to have more travis info

### DIFF
--- a/docs/Codebase/index.md
+++ b/docs/Codebase/index.md
@@ -168,7 +168,7 @@ Script for [Travis-CI](Project-Information/Travis-CI).
 
 ### .travis.yml
 
-Provides Travis-CI with the relevant information to test TFB. See the 
+Provides Travis-CI with the relevant information to test TFB. New frameworks must be added to `.travis.yml` so that travis will test the framework as part of our continuous integration scheme. See the 
 [Travis-CI](Project-Information/Travis-CI) section for more information.
 
 ### benchmark.cfg


### PR DESCRIPTION
I can't find the original comment, but someone noted that there wasn't enough info in the docs regarding `.travis.yml` and adding ones framework to it so that it will be tested by Travis.

Will mark with :shipit: when I'm done adding files, opening PR now.