### PR TITLE
Update deprecated mkdocs structure and links

### DIFF
--- a/docs/About/TechEmpower.md
+++ b/docs/About/TechEmpower.md
@@ -1,4 +1,4 @@
-![TechEmpower Logo](img/te-logo-blue-400.png)
+![TechEmpower Logo](../../img/te-logo-blue-400.png)
 
 ##What is TechEmpower?
 

--- a/docs/Benchmarking/Getting-Started-Benchmarking.md
+++ b/docs/Benchmarking/Getting-Started-Benchmarking.md
@@ -1,6 +1,6 @@
 This is the getting started guide for __benchmarking__. 
 If you're interested in __development__ please visit the 
-[getting started guide for development](Development/Getting-Started).
+[getting started guide for development](../Development/Getting-Started).
 
 You will need three computers (or virtual machines) networked 
 together to fill the three benchmark roles of database server, 
@@ -14,7 +14,7 @@ SQL server, there are some limited helper scripts available at
 the moment. We welcome any pull requests along these lines. 
 While you can always use *manual deployment*, automated scripts 
 exist for many scenarios. Take a look at the 
-[Summary of Script Directories section](Codebase/Summary-of-Script-Directories) 
+[Summary of Script Directories section](../Codebase/Summary-of-Script-Directories) 
 to figure out which directory has scripts relevant to your use case. 
 
 *Please note: Running this software will make many modifications 

--- a/docs/Benchmarking/Running-the-Benchmark.md
+++ b/docs/Benchmarking/Running-the-Benchmark.md
@@ -1,5 +1,5 @@
 First, ensure that you have a 
-[benchmarking evironment set up and configured](Benchmarking/Getting-Started-Benchmarking)
+[benchmarking evironment set up and configured](Getting-Started-Benchmarking)
 correctly.
 
 If you plan to run the benchmark and compare results, you need to run in _benchmark_ 
@@ -17,8 +17,9 @@ you will need to have passwordless sudo access
 Once you have cloned our repository, run `toolset/run-tests.py --help` for detailed help
 on running in _benchmark_ mode. 
 
-If you wish to benchmark on Amazon EC2, see [our scripts](deployment/vagrant-production) for 
-launching a benchmark-ready Amazon environment. 
+If you wish to benchmark on Amazon EC2, see
+[our scripts](https://github.com/TechEmpower/FrameworkBenchmarks/tree/master/deployment/vagrant-production)
+for launching a benchmark-ready Amazon environment.
 
 If you are not an expert, please ensure your setup can run in _verify_ mode before 
 attempting to run in _benchmark_ mode. 

--- a/docs/Benchmarking/index.md
+++ b/docs/Benchmarking/index.md
@@ -1,5 +1,5 @@
 If you're looking to run the benchmarks yourself, you're 
-in the right place. However, see the [development section](Development) 
+in the right place. However, see the [development section](../Development) 
 if you'd like to verify a certain test works, update a test, or 
 add a new test/framework. 
 
@@ -7,5 +7,5 @@ add a new test/framework.
 
 | Page | Summary |
 |:---- |:------- |
-[Getting Started](Benchmarking/Getting-Started-Benchmarking) | Covers setting up the benchmark suite, manual deployment, and automated deployment.
-[Running the Benchmark](Benchmarking/Running-the-Benchmark) | A guide on how to run the benchmark and specific configurations only applicable after everything is set up and configured to do so.
+[Getting Started](Getting-Started-Benchmarking) | Covers setting up the benchmark suite, manual deployment, and automated deployment.
+[Running the Benchmark](Running-the-Benchmark) | A guide on how to run the benchmark and specific configurations only applicable after everything is set up and configured to do so.

--- a/docs/Codebase/Framework-Files.md
+++ b/docs/Codebase/Framework-Files.md
@@ -207,4 +207,4 @@ or call the other test with `toolset/run-tests.py --mode verify --test compojure
   * `display_name (metadata):` How to render this test permutation's name on the results web site.  Some permutation names can be really long, so the display_name is provided in order to provide something more succinct.
   * `versus (optional):` The name of another test (elsewhere in this project) that is a subset of this framework.  This allows for the generation of the framework efficiency chart in the results web site. For example, Compojure is compared to "servlet" since Compojure is built on the Servlets platform.
 
-The [requirements section](Project-Information/Framework-Tests#requirements) explains the expected response for each URL as well all metadata options available. 
+The [requirements section](../Project-Information/Framework-Tests#requirements) explains the expected response for each URL as well all metadata options available. 

--- a/docs/Codebase/index.md
+++ b/docs/Codebase/index.md
@@ -49,7 +49,7 @@ Information for deploying the benchmark on a range of cloud or
 self-hosted environments. While you can always use manual deployment, 
 automated scripts exist for many scenarios. Explinations of the 
 subdirectories are within 
-[Summary of Script Directories section](Codebase/Summary-of-Script-Directories).
+[Summary of Script Directories section](Summary-of-Script-Directories).
 
 ### frameworks/
 
@@ -68,7 +68,7 @@ Because the information for each language varies so much, each language
 should have its own README. This should include information like which 
 software versions are used, special instructions for adding a new 
 framework in that language, and places where you can get help specific 
-to that language. See the [Language README Formatting Guide](Development/Readme-Formats#language-readmes) 
+to that language. See the [Language README Formatting Guide](../Development/Readme-Formats#language-readmes) 
 for a more detailed guide.
 
 #### Framework README.md
@@ -77,7 +77,7 @@ Because the information for each framework varies so much, each framework
 should have its own README. This should include information like which 
 software versions are used, special instructions for adding a new 
 variation in that framework, and places where you can get help specific 
-to that framework. See the [Framework README Formatting Guide](Development/Readme-Formats#framework-readmes) 
+to that framework. See the [Framework README Formatting Guide](../Development/Readme-Formats#framework-readmes) 
 for a more detailed guide.
 
 #### Framework Specific Files
@@ -90,7 +90,7 @@ files that are required by the TFB suite. These are:
 * install.sh
 * setup.sh
 
-See the section on [Framework Specific Files](Codebase/Framework-Files) 
+See the section on [Framework Specific Files](Framework-Files) 
 for more information.
 
 #### Source Code File
@@ -132,7 +132,7 @@ This directory contains files that implement or support the benchmark feature:
 * `framework_test.py`: Methods to run a framework's tests. Called by `benchmarker.py`.
 
 These files are not meant for you to run directly. For instructions on running the 
-benchmark, please refer to the [benchmarking section](Benchmarking).
+benchmark, please refer to the [benchmarking section](../Benchmarking).
 
 #### setup/
 
@@ -148,9 +148,9 @@ windows: Scripts to setup the Windows server.
 These directories help organize the installation scripts into four 
 cagegories (frameworks, languages, systools, and webservers), 
 which are called by [`installer.py`](#installerpy) when tests are run. 
-Visit the [installation script section](Development/Add-Benchmark-Scripts#installation-scripts) 
+Visit the [installation script section](../Development/Add-Benchmark-Scripts#installation-scripts) 
 for guidelines on writing an installation script, or visit the 
-[installer file section](Codebase/SetupFiles#installer-file) for 
+[installer file section](Setup-Files#installer-file) for 
 more information on how the installer scripts are called.
 
 ##### installer.py
@@ -159,28 +159,28 @@ The `installer.py` file calls into the shell to perform all installation steps.
 It installs three different sets of software, the server software we want to 
 test, the database that we want to use with the server software, and the client 
 software that we want to use to generate load for the server. The 
-[installer file section](Codebase/SetupFiles#installer-file) gives 
+[installer file section](Setup-Files#installer-file) gives 
 an overview of how this installation process works.
 
 #### test/
 
-Script for [Travis-CI](Project-Information/Travis-CI).
+Script for [Travis-CI](../Project-Information/Travis-CI).
 
 ### .travis.yml
 
 Provides Travis-CI with the relevant information to test TFB. See the 
-[Travis-CI](Project-Information/Travis-CI) section for more information.
+[Travis-CI](../Project-Information/Travis-CI) section for more information.
 
 ### benchmark.cfg
 
 This file sets up user/environment specific information that TFB needs to 
 know in order to properly run framework tests. See the 
-[Configuration File section](Codebase/Configuration-File) for more information.
+[Configuration File section](Configuration-File) for more information.
 
 # Contents
 
 | Page | Summary |
 |:---- |:------- |
-[Configuration File](Codebase/Configuration-File) | Configures set up specifications specific to each user and system.
-[Framework Specific Files](Codebase/Framework-Files) | Files specific to each individual framework for use with the benchmarking suite.
-[Summary of Script Directories](Codebase/Summary-of-Script-Directories) | Guide to directories that assist with scripts for setting up different environments.
+[Configuration File](Configuration-File) | Configures set up specifications specific to each user and system.
+[Framework Specific Files](Framework-Files) | Files specific to each individual framework for use with the benchmarking suite.
+[Summary of Script Directories](Summary-of-Script-Directories) | Guide to directories that assist with scripts for setting up different environments.

--- a/docs/Development/Add-Frameworks-or-Tests.md
+++ b/docs/Development/Add-Frameworks-or-Tests.md
@@ -1,17 +1,17 @@
 When adding a new framework or new test to an existing framework, please follow 
 these steps:
 
-* Add/Update an [install.sh file](Codebase/Framework-Files#install-file).
-* Add/Update a [setup file](Codebase/Framework-Files#setup-file).
-* Add/Update a [benchmark_config.json](Codebase/Framework-Files#benchmark-config-file).
-* Implement at least one [test](Project-Information/Framework-Tests#test-types) 
+* Add/Update an [install.sh file](../Codebase/Framework-Files#install-file).
+* Add/Update a [setup file](../Codebase/Framework-Files#setup-file).
+* Add/Update a [benchmark_config.json](../Codebase/Framework-Files#benchmark-config-file).
+* Implement at least one [test](../Project-Information/Framework-Tests#test-types) 
 (we'd be even happier with six completed tests). When creating a database test, 
 use the table/collection `hello_world`. Our database setup scripts are stored 
 inside the `config/` folder if you need to see the database schema.
-* [Test your framework](Development/Testing-and-Debugging) appropriately.
-* Add/Update a [README](Development/Readme-Formats#language-readmes) for your 
+* [Test your framework](Testing-and-Debugging) appropriately.
+* Add/Update a [README](Readme-Formats#language-readmes) for your 
 framework.
-* Add/Update a [README](Development/Readme-Formats#framework-readmes) for your
+* Add/Update a [README](Readme-Formats#framework-readmes) for your
 language.
 * When all tests are passing, submit a pull request following the 
-[pull request procedure](Development/Contributing-Guide#github-pull-request-procedure).
+[pull request procedure](Contributing-Guide#github-pull-request-procedure).

--- a/docs/Development/Contributing-Guide.md
+++ b/docs/Development/Contributing-Guide.md
@@ -28,7 +28,7 @@ ones inside specific framework directories.
 * __Use the Development Virtual Machine__: Our Vagrant scripts can setup a VM for you
 that looks nearly identical to our test environment. This is even better than relying
 on the Travis-CI verification, and you are strongly encouraged to use this. See 
-the [installation guide](Development/Installation-Guide#vagrant-development-environment) 
+the [installation guide](Installation-Guide#vagrant-development-environment) 
 for specifics.
 
 # Github Pull Request Procedure
@@ -49,15 +49,15 @@ if you haven't done so in a commit. Just include the
 like "Resolves #1" and you're good.
 * Add any labels/milestone tags that are relevant to your pull request.
 * If you'd like to submit a pull request for this documenation, see the 
-[about documenation page](About/Documentation).
+[about documenation page](../About/Documentation).
 
 # GitHub Issue Procedure
 * You can submit an issue for almost anything, but also consider that some assistance can 
-be provided by [contacting the community](Support/Converse). Some valid (and encouraged!) 
+be provided by [contacting the community](../Support/Converse). Some valid (and encouraged!) 
 example reasons to open an issue:
     * Found a bug
     * Request to see a new framework implemented
     * Framework/language readme information out of date
 * Add any appropriate labels/milestone tags for easier identification.
 * If the issue is regarding this documentation, see the 
-[about documenation page](About/Documentation).
+[about documenation page](../About/Documentation).

--- a/docs/Development/Getting-Started.md
+++ b/docs/Development/Getting-Started.md
@@ -1,16 +1,16 @@
-This is the getting started guide for __development__. If you're interested in __benchmarking__ please visit the [getting started guide for benchmarking](Benchmarking/Getting-Started-Benchmarking).
+This is the getting started guide for __development__. If you're interested in __benchmarking__ please visit the [getting started guide for benchmarking](../Benchmarking/Getting-Started-Benchmarking).
 
 1. __Get TFB__
     * [Fork](https://help.github.com/articles/fork-a-repo/) the [TFB project](https://github.com/TechEmpower/FrameworkBenchmarks/) to your own repository.
     * Clone your TFB repository to your local environment to get started.
 2. __Set up a development environment__  
     * Typically a TFB environment is set up by using a remote server dedicated to this project or by using a virtual machine. Because you're getting set up for development, you can use an environment with a single computer running the database, the load generation system, and the web framework. 
-    * Get started quickly and [set up your development environment with vagrant](Development/Installation-Guide#vagrant-development-environment), or
-    * [Click here for the guide to get your development environment set up.](Development/Installation-Guide) *Note: We provide [scripts](Codebase/Summary-of-Script-Directories) for configuring a Linux development environment using either Virtualbox or Amazon EC2, and are actively searching for help adding Windows.*
+    * Get started quickly and [set up your development environment with vagrant](Installation-Guide#vagrant-development-environment), or
+    * [Click here for the guide to get your development environment set up.](Installation-Guide) *Note: We provide [scripts](../Codebase/Summary-of-Script-Directories) for configuring a Linux development environment using either Virtualbox or Amazon EC2, and are actively searching for help adding Windows.*
 3. __Enable Travis-CI__
-    * [Enable Travis-CI](Development/Testing-and-Debugging#travis-ci) on your project fork, so that any commits you send to Github are automatically verified for correctness (e.g. meeting all [benchmark requirements](Project-Information/Framework-Tests#requirements)). 
+    * [Enable Travis-CI](Testing-and-Debugging#travis-ci) on your project fork, so that any commits you send to Github are automatically verified for correctness (e.g. meeting all [benchmark requirements](../Project-Information/Framework-Tests#requirements)).
 4. __Configure Your Environment__
-    * Create a [benchmark.cfg file](Codebase/Configuration-File), which is the benchmark.cfg.example with your specific configurations.
+    * Create a [benchmark.cfg file](../Codebase/Configuration-File), which is the benchmark.cfg.example with your specific configurations.
 5. __Run a Test__
     * `toolset/run-tests.py --install server --mode verify --test ${your-test-here}` *Note: Only include "--install server" if you're running the test for the first time.*
 6. __Clean Up__

--- a/docs/Development/Installation-Guide.md
+++ b/docs/Development/Installation-Guide.md
@@ -1,6 +1,6 @@
 If you're looking to quickly get started developing using the vagrant development environment, consider the [vagrant development environment guide](#vagrant-development-environment). 
 
-Take a look at the [Summary of Script Directories section](Codebase/Summary-of-Script-Directories) to figure out which directory has scripts relevant to your use case (development or benchmarking).
+Take a look at the [Summary of Script Directories section](../Codebase/Summary-of-Script-Directories) to figure out which directory has scripts relevant to your use case (development or benchmarking).
 
 #Installation Basics
 
@@ -157,7 +157,7 @@ We use the `--install-only` flag in our examples to
 prevent launching tests at this stage. All of these commands 
 should be run from the `app server` - it will SSH into other
 hosts as needed. For more information on how TFB installation 
-works, see [here](deployment). 
+works, see [here](../Benchmarking/Getting-Started-Benchmarking/#benchmark-suite-deployment).
 
 **Setting up the `load server`**
 

--- a/docs/Development/Testing-and-Debugging.md
+++ b/docs/Development/Testing-and-Debugging.md
@@ -58,9 +58,9 @@ permutation to your `benchmark_config.json` file for the Windows test.  When
 the benchmark script runs on Linux, it skips tests where `os` in 
 `Windows` and vice versa.
 * Add the necessary tweaks to your 
-[setup file](Codebase/Framework-Files#setup-file) to start and stop on 
+[setup file](../Codebase/Framework-Files#setup-file) to start and stop on 
 the new operating system.  See, for example, 
-[the script for Go](https://github.com/TechEmpower/FrameworkBenchmarks/tree/master/frameworks/Go/go/setup.sh).
+[the script for Go](https://github.com/TechEmpower/FrameworkBenchmarks/tree/master/frameworks/Go/go-raw/setup.sh).
 * Test on Windows and Linux to make sure everything works as expected.
 
 # Travis-CI
@@ -69,7 +69,7 @@ as simple as going to travis-ci.org, using the `Log in with Github`
 button, and enabling Travis-CI for your fork. When your development is 
 done and your changes pass the Travis-CI verification, submit a pull 
 request with confidence that it can be merged quickly. 
-[Read more about TFB and Travis-CI](Project-Information/Travis-CI).
+[Read more about TFB and Travis-CI](../Project-Information/Travis-CI).
 
 # Debugging
 

--- a/docs/Development/index.md
+++ b/docs/Development/index.md
@@ -1,6 +1,6 @@
 If you'd like to verify a certain test works, update a test, or 
 add a new test/framework, you're in the right place. 
-However, see the [development section](Development) 
+However, see the [benchmarking section](../Benchmarking) 
 if you're looking to run the benchmarks yourself.
 
 The community has consistently helped in making these tests better, 
@@ -11,8 +11,8 @@ practices and guidelines will help to keep us all on the same page.
 
 | Page | Summary |
 |:---- |:------- |
-[Getting Started](Development/Getting-Started) | A brief overview of what's necessary to get started developing for TFB.
-[Contributing Guide](Development/Contributing-Guide) | Overview of guidelines and general practices for contributing.
-[Installation Guide](Development/Installation-Guide) | Suggestions and instructions to get a development environment set up.
-[Add Frameworks or Tests](Development/Add-Frameworks-or-Tests) | Everything that's required and recommended to add or update a framewrok.
-[Testing and Debugging](Development/Testing-and-Debugging) | Instructions and help for testing and debugging a framework.
+[Getting Started](Getting-Started) | A brief overview of what's necessary to get started developing for TFB.
+[Contributing Guide](Contributing-Guide) | Overview of guidelines and general practices for contributing.
+[Installation Guide](Installation-Guide) | Suggestions and instructions to get a development environment set up.
+[Add Frameworks or Tests](Add-Frameworks-or-Tests) | Everything that's required and recommended to add or update a framewrok.
+[Testing and Debugging](Testing-and-Debugging) | Instructions and help for testing and debugging a framework.

--- a/docs/Project-Information/index.md
+++ b/docs/Project-Information/index.md
@@ -5,8 +5,8 @@ The TechEmpower Framework Benchmarks project (TFB for short) is by its nature co
 
 | Page | Summary |
 |:---- |:------- |
-[Basics Concepts](Project-Information/Concepts) | The basic concepts surrounding TFB.
-[Framework Tests](Project-Information/Framework-Tests) | Test descriptions & requirements.
-[Environment](Project-Information/Environment) | Project environment details.
-[Travis-CI](Project-Information/Travis-CI) | Details related to TFB and Travis-CI.
-[Expected Questions](Project-Information/Expected-Questions) | Questions we're expecting to answer.
+[Basics Concepts](Concepts) | The basic concepts surrounding TFB.
+[Framework Tests](Framework-Tests) | Test descriptions & requirements.
+[Environment](Environment) | Project environment details.
+[Travis-CI](Travis-CI) | Details related to TFB and Travis-CI.
+[Expected Questions](Expected-Questions) | Questions we're expecting to answer.

--- a/docs/Support/index.md
+++ b/docs/Support/index.md
@@ -2,5 +2,5 @@
 
 | Page | Summary |
 |:---- |:------- |
-[Join the Conversation](Support/Converse) | Get in contact with the TFB community.
-[FAQ](Support/FAQ) | Answers to frequently asked questions.
+[Join the Conversation](Converse) | Get in contact with the TFB community.
+[FAQ](FAQ) | Answers to frequently asked questions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ The major sections of the documentation are:
 [Project Information](Project-Information/)| General information regarding the project terminology, concepts, and project scope. 
 [Development](Development/)                | Guides and documents that assist with getting set up for development, adding a test or framework, and adding features to the benchmark suite. 
 [Benchmarking](Benchmarking/)              | Assistance getting set up to run the benchmark and running the benchmarks yourself. 
+[Codebase](Codebase/)                      | See how the framework benchmarks are structured and understand the purpose of the files.
 [Support](Support/)                        | Get more help via FAQs or by getting in touch with the community. 
 
 _Note: There are READMEs pertaining to specific test implementations that exist outside of this documentation. Each of those READMEs is located within the main project's directory structure, such as within the directories for specific languages, frameworks, and 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,54 +1,46 @@
 site_name: TechEmpower Framework Benchmarks
-site_url: /
+site_url: http://frameworkbenchmarks.readthedocs.org/en/latest
 site_description: Documentation for TechEmpower Framework Benchmarks.
 site_favicon: img/favicon.png
 repo_url: https://github.com/TechEmpower/TFB-Documentation
+repo_name: TFB-Documentation
 theme: readthedocs
-pages: 
-- ['index.md']
 
-# **************************
-# **DROP DOWN MENU OPTIONS** 
-# **************************
-
-# Project Information:
-- ['Project-Information/index.md', 'Project Information']
-- ['Project-Information/Concepts.md', 'Project Information', 'Basic Concepts']
-- ['Project-Information/Framework-Tests.md', 'Project Information', 'Framework Tests']
-- ['Project-Information/Environment.md', 'Project Information', 'Environment']
-- ['Project-Information/Travis-CI.md', 'Project Information', 'Travis-CI']
-- ['Project-Information/Expected-Questions.md', 'Project Information', 'Expected Questions']
-- ['Project-Information/Results-Website.md', 'Project Information', 'Results Website']
-
-# Development:
-- ['Development/index.md', 'Development']
-- ['Development/Getting-Started.md', 'Development', 'Getting Started']
-- ['Development/Contributing-Guide.md', 'Development', 'Contributing Guide']
-- ['Development/Installation-Guide.md', 'Development', 'Installation Guide']
-- ['Development/Add-Frameworks-or-Tests.md', 'Development', 'Add Frameworks or Tests']
-- ['Development/Testing-and-Debugging.md', 'Development', 'Testing and Debugging']
-- ['Development/Add-Benchmark-Scripts.md', 'Development', 'Add Benchmark Scripts']
-- ['Development/Readme-Formats.md', 'Development', 'Readme Formats']
-
-# Benchmarking:
-- ['Benchmarking/index.md', 'Benchmarking']
-- ['Benchmarking/Getting-Started-Benchmarking.md', 'Benchmarking', 'Getting Started']
-- ['Benchmarking/Running-the-Benchmark.md', 'Benchmarking', 'Run the Benchmark']
-
-# Codebase
-- ['Codebase/index.md', 'Codebase']
-- ['Codebase/Configuration-File.md', 'Codebase', 'Configuration File']
-- ['Codebase/Framework-Files.md', 'Codebase', 'Framework Specific Files']
-- ['Codebase/Summary-of-Script-Directories.md', 'Codebase', 'Summary of Script Directories']
-- ['Codebase/Setup-Files.md', 'Codebase', 'Setup Files']
-
-# About:
-- ['About/Framework-Benchmarks.md', 'About', 'Framework Benchmarks']
-- ['About/TechEmpower.md', 'About', 'TechEmpower']
-- ['About/Documentation.md', 'About', 'Documentation']
-- ['About/License.md', 'About', 'License']
-
-# Support
-- ['Support/index.md', 'Support']
-- ['Support/Converse.md', 'Support', 'Join the Conversation']
-- ['Support/FAQ.md', 'Support', 'FAQ']
+pages:
+- Home: 'index.md'
+- Project Information:
+  - 'Project Information Overview': 'Project-Information/index.md'
+  - 'Basic Concepts' : 'Project-Information/Concepts.md'
+  - 'Framework Tests' : 'Project-Information/Framework-Tests.md'
+  - 'Environment' : 'Project-Information/Environment.md'
+  - 'Travis-CI' : 'Project-Information/Travis-CI.md'
+  - 'Expected Questions' : 'Project-Information/Expected-Questions.md'
+  - 'Results Website' : 'Project-Information/Results-Website.md'
+- Development:
+  - 'Development Overview': 'Development/index.md'
+  - 'Getting Started': 'Development/Getting-Started.md'
+  - 'Contributing Guide': 'Development/Contributing-Guide.md'
+  - 'Installation Guide': 'Development/Installation-Guide.md'
+  - 'Add Framework or Tests': 'Development/Add-Frameworks-or-Tests.md'
+  - 'Testing and Debugging': 'Development/Testing-and-Debugging.md'
+  - 'Add Benchmark Scripts': 'Development/Add-Benchmark-Scripts.md'
+  - 'Readme Formats': 'Development/Readme-Formats.md'
+- Benchmarking:
+  - 'Benchmarking Overview': 'Benchmarking/index.md'
+  - 'Getting Started': 'Benchmarking/Getting-Started-Benchmarking.md'
+  - 'Run the Benchmark': 'Benchmarking/Running-the-Benchmark.md'
+- Codebase:
+  - 'Codebase Overview': 'Codebase/index.md'
+  - 'Configuration File': 'Codebase/Configuration-File.md'
+  - 'Framework Files': 'Codebase/Framework-Files.md'
+  - 'Summary of Script Directories': 'Codebase/Summary-of-Script-Directories.md'
+  - 'Setup Files': 'Codebase/Setup-Files.md'
+- About:
+  - 'Framework Benchmarks': 'About/Framework-Benchmarks.md'
+  - 'TechEmpower': 'About/TechEmpower.md'
+  - 'Documentation': 'About/Documentation.md'
+  - 'License': 'About/License.md'
+- Support:
+  - 'Support Overview': 'Support/index.md'
+  - 'Join the Conversation': 'Support/Converse.md'
+  - 'FAQ': 'Support/FAQ.md'


### PR DESCRIPTION
Documentation builds are failing. This should fix that.

closes #29