### PR TITLE
Delete instructions for vagrant to use install server

### DIFF
--- a/docs/Development/Installation-Guide.md
+++ b/docs/Development/Installation-Guide.md
@@ -214,8 +214,9 @@ $ vagrant up
 # Enter the VM, then run a test
 $ vagrant ssh
 vagrant@TFB-all:~$ cd ~/FrameworkBenchmarks
-vagrant@TFB-all:~/FrameworkBenchmarks$ toolset/run-tests.py --install server --mode verify --test beego
-# For non-Windows users: if the local version of your code does not mirror the code in your virtual machine, then run the following:
+# Note: "--install server" is unnecessary for vagrant and is not included below
+vagrant@TFB-all:~/FrameworkBenchmarks$ toolset/run-tests.py --mode verify --test gemini
+# For non-Windows users only (will break Windows environments): if the local version of your code does not mirror the code in your virtual machine, then run the following:
 vagrant@TFB-all:~/FrameworkBenchmarks$ sudo mount.vboxsf -o uid=1000,gid=1000 FrameworkBenchmarks ~/FrameworkBenchmarks
 vagrant@TFB-all:~/FrameworkBenchmarks$ mkdir -p /tmp/TFB_installs
 vagrant@TFB-all:~/FrameworkBenchmarks$ mkdir -p ~/FrameworkBenchmarks/installs


### PR DESCRIPTION
- "--install server" is unnecessary for vagrant; take this out of the documentation
- Clarify the note that commands are for non-Windows users (explain that it will break Windows)