### PR TITLE
Delete reference to results/ec2/latest/... as file structure has changed

### DIFF
--- a/docs/Development/Installation-Guide.md
+++ b/docs/Development/Installation-Guide.md
@@ -181,7 +181,7 @@ toolset/run-tests.py --mode verify --test gemini
 ```
 
 You can find the results for this verification step under the directory:
-`results/ec2/latest/logs/gemini`. There should be an `err` and an `out`
+`results/latest/logs/gemini`. There should be an `err` and an `out`
 file.
 
 You can choose to selectively install components by using the 

--- a/docs/Development/Testing-and-Debugging.md
+++ b/docs/Development/Testing-and-Debugging.md
@@ -82,7 +82,7 @@ by clicking on the checkmark or red 'X' to dig into your specific test.
 
 ## Finding output logs
 
-Logs file locations use the format `results/ec2/latest/logs/wt/err.txt`. 
+Logs file locations use the format `results/latest/logs/wt/err.txt`.
 The general structure is `results/<run name>/<timestamp>/logs/<test name>/<file>`.
 You can use the `--name` flag to change the `<run name>`.
 If you re-run the same test multiple times, you will get a different folder


### PR DESCRIPTION
- If FrameworkBenchmarks PR #2013 is merged, then results will no longer have a name attribute with default name "ec2" and the file structure will become results/latest/... instead of results/ec2/latest...
- Delete documentation referring to that file structure

** Only merge if TFB PR #2013 is merged **