### PR TITLE
Update links to FAQs and Expected Questions

### DIFF
--- a/docs/Support/FAQ.md
+++ b/docs/Support/FAQ.md
@@ -1,4 +1,5 @@
 # FAQ
+__Please also see [Expected Questions](../Project-Information/Expected-Questions.md) for more questions and answers.__
 1. There is synthetic routing implemented for the platforms that do not provide native routing. Should we force them to have similar routing logic to other platforms?
 
     > It's up to you, but adding trivial synthetic routing shouldn't affect the numbers to a measurable degree.

--- a/docs/Support/index.md
+++ b/docs/Support/index.md
@@ -3,4 +3,4 @@
 | Page | Summary |
 |:---- |:------- |
 [Join the Conversation](Converse) | Get in contact with the TFB community
-[FAQ](FAQ) | Answers to frequently asked questions and links to helpful discussions
+[FAQ and Helpful Discussion](FAQ) | Answers to frequently asked questions and links to helpful discussions


### PR DESCRIPTION
- Link to Expected Questions in the FAQ (these should probably just be merged at some point)
- Rename the FAQ/Helpful Discussion section