### PR TITLE
Add Travis CI info to procedure for adding frameworks

### DIFF
--- a/docs/Development/Add-Frameworks-or-Tests.md
+++ b/docs/Development/Add-Frameworks-or-Tests.md
@@ -8,10 +8,13 @@ these steps:
 (we'd be even happier with six completed tests). When creating a database test, 
 use the table/collection `hello_world`. Our database setup scripts are stored 
 inside the `config/` folder if you need to see the database schema.
-* [Test your framework](Testing-and-Debugging) appropriately.
 * Add/Update a [README](Readme-Formats#language-readmes) for your 
 framework.
 * Add/Update a [README](Readme-Formats#framework-readmes) for your
 language.
+* Add an entry for the framework test directory in `.travis.yml` if the framework is new to the benchmarks.
+* [Test your framework](Testing-and-Debugging) appropriately.
+    * Ensure the framework tests implemented pass in your local environment.
+    * Travis CI will test the framework when a pull request is opened. _Tip: Setup your own [Travis CI](https://travis-ci.org) account and know the outcome of the tests before you submit a merge request. See [Travis CI Tips and Tricks](../Project-Information/Travis-CI#tricks-and-tips-for-travis-ci) for more details._
 * When all tests are passing, submit a pull request following the 
 [pull request procedure](Contributing-Guide#github-pull-request-procedure).


### PR DESCRIPTION
The information to add a line to `.travis.yml` when adding a new framework was within the "test your framework" link. This change basically makes it a checklist item on the main Add Framework or Test page for added clarity.